### PR TITLE
Add support for `brightnessctl` for blacklight control

### DIFF
--- a/1080p/applets/android/backlight.sh
+++ b/1080p/applets/android/backlight.sh
@@ -14,7 +14,12 @@ msg() {
 }
 
 ## Get Brightness
-if [[ -f /usr/bin/blight ]]; then
+if [[ -f /bin/brightnessctl ]]; then
+	BNESS="$(brightnessctl get)"
+	MAX="$(brightnessctl max)"
+	PERC="$((BNESS*100/MAX))"
+	BLIGHT=${PERC%.*}
+elif [[ -f /usr/bin/blight ]]; then
 	DEVICE=$(ls /sys/class/backlight | head -n 1)
 	BNESS="$(blight -d $DEVICE get brightness)"
 	PERC="$(($BNESS*100/255))"
@@ -48,23 +53,29 @@ options="$ICON_UP\n$ICON_OPT\n$ICON_DOWN"
 ## Main
 chosen="$(echo -e "$options" | $rofi_command -p "$BLIGHT%" -dmenu -selected-row 1)"
 case $chosen in
-    $ICON_UP)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set +10% && $notify "Brightness Up $ICON_UP"
+    "$ICON_UP")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set +10% && $notify "Brightness Up $ICON_UP"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set +10% && $notify "Brightness Up $ICON_UP"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -inc 10 && $notify "Brightness Up $ICON_UP"
 		fi
         ;;
-    $ICON_DOWN)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set -10% && $notify "Brightness Down $ICON_DOWN"
+    "$ICON_DOWN")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 10%- && $notify "Brightness Down $ICON_DOWN"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set -10% && $notify "Brightness Down $ICON_DOWN"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -dec 10 && $notify "Brightness Down $ICON_DOWN"
 		fi
         ;;
-    $ICON_OPT)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set 25% && $notify "Optimal Brightness $ICON_OPT"
+    "$ICON_OPT")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 25% && $notify "Optimal Brightness $ICON_OPT"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set 25% && $notify "Optimal Brightness $ICON_OPT"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -set 30 && $notify "Optimal Brightness $ICON_OPT"
 		fi

--- a/1080p/applets/applets/backlight.sh
+++ b/1080p/applets/applets/backlight.sh
@@ -16,7 +16,12 @@ msg() {
 }
 
 ## Get Brightness
-if [[ -f /usr/bin/blight ]]; then
+if [[ -f /bin/brightnessctl ]]; then
+	BNESS="$(brightnessctl get)"
+	MAX="$(brightnessctl max)"
+	PERC="$((BNESS*100/MAX))"
+	BLIGHT=${PERC%.*}
+elif [[ -f /usr/bin/blight ]]; then
 	DEVICE=$(ls /sys/class/backlight | head -n 1)
 	BNESS="$(blight -d $DEVICE get brightness)"
 	PERC="$(($BNESS*100/255))"
@@ -50,23 +55,29 @@ options="$ICON_UP\n$ICON_OPT\n$ICON_DOWN"
 ## Main
 chosen="$(echo -e "$options" | $rofi_command -p "$BLIGHT%" -dmenu -selected-row 1)"
 case $chosen in
-    $ICON_UP)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set +10% && $notify "Brightness Up $ICON_UP"
+    "$ICON_UP")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set +10% && $notify "Brightness Up $ICON_UP"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set +10% && $notify "Brightness Up $ICON_UP"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -inc 10 && $notify "Brightness Up $ICON_UP"
 		fi
         ;;
-    $ICON_DOWN)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set -10% && $notify "Brightness Down $ICON_DOWN"
+    "$ICON_DOWN")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 10%- && $notify "Brightness Down $ICON_DOWN"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set -10% && $notify "Brightness Down $ICON_DOWN"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -dec 10 && $notify "Brightness Down $ICON_DOWN"
 		fi
         ;;
-    $ICON_OPT)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set 25% && $notify "Optimal Brightness $ICON_OPT"
+    "$ICON_OPT")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 25% && $notify "Optimal Brightness $ICON_OPT"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set 25% && $notify "Optimal Brightness $ICON_OPT"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -set 30 && $notify "Optimal Brightness $ICON_OPT"
 		fi

--- a/1080p/applets/menu/backlight.sh
+++ b/1080p/applets/menu/backlight.sh
@@ -16,7 +16,12 @@ msg() {
 }
 
 ## Get Brightness
-if [[ -f /usr/bin/blight ]]; then
+if [[ -f /bin/brightnessctl ]]; then
+	BNESS="$(brightnessctl get)"
+	MAX="$(brightnessctl max)"
+	PERC="$((BNESS*100/MAX))"
+	BLIGHT=${PERC%.*}
+elif [[ -f /usr/bin/blight ]]; then
 	DEVICE=$(ls /sys/class/backlight | head -n 1)
 	BNESS="$(blight -d $DEVICE get brightness)"
 	PERC="$(($BNESS*100/255))"
@@ -50,23 +55,29 @@ options="$ICON_UP\n$ICON_OPT\n$ICON_DOWN"
 ## Main
 chosen="$(echo -e "$options" | $rofi_command -p "$BLIGHT%  :  $MSG" -dmenu -selected-row 1)"
 case $chosen in
-    $ICON_UP)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set +10% && $notify "Brightness Up $ICON_UP"
+    "$ICON_UP")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set +10% && $notify "Brightness Up $ICON_UP"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set +10% && $notify "Brightness Up $ICON_UP"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -inc 10 && $notify "Brightness Up $ICON_UP"
 		fi
         ;;
-    $ICON_DOWN)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set -10% && $notify "Brightness Down $ICON_DOWN"
+    "$ICON_DOWN")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 10%- && $notify "Brightness Down $ICON_DOWN"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set -10% && $notify "Brightness Down $ICON_DOWN"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -dec 10 && $notify "Brightness Down $ICON_DOWN"
 		fi
         ;;
-    $ICON_OPT)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set 25% && $notify "Optimal Brightness $ICON_OPT"
+    "$ICON_OPT")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 25% && $notify "Optimal Brightness $ICON_OPT"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set 25% && $notify "Optimal Brightness $ICON_OPT"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -set 30 && $notify "Optimal Brightness $ICON_OPT"
 		fi

--- a/720p/applets/android/backlight.sh
+++ b/720p/applets/android/backlight.sh
@@ -14,7 +14,12 @@ msg() {
 }
 
 ## Get Brightness
-if [[ -f /usr/bin/blight ]]; then
+if [[ -f /bin/brightnessctl ]]; then
+	BNESS="$(brightnessctl get)"
+	MAX="$(brightnessctl max)"
+	PERC="$((BNESS*100/MAX))"
+	BLIGHT=${PERC%.*}
+elif [[ -f /usr/bin/blight ]]; then
 	DEVICE=$(ls /sys/class/backlight | head -n 1)
 	BNESS="$(blight -d $DEVICE get brightness)"
 	PERC="$(($BNESS*100/255))"
@@ -48,23 +53,29 @@ options="$ICON_UP\n$ICON_OPT\n$ICON_DOWN"
 ## Main
 chosen="$(echo -e "$options" | $rofi_command -p "$BLIGHT%" -dmenu -selected-row 1)"
 case $chosen in
-    $ICON_UP)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set +10% && $notify "Brightness Up $ICON_UP"
+    "$ICON_UP")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set +10% && $notify "Brightness Up $ICON_UP"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set +10% && $notify "Brightness Up $ICON_UP"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -inc 10 && $notify "Brightness Up $ICON_UP"
 		fi
         ;;
-    $ICON_DOWN)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set -10% && $notify "Brightness Down $ICON_DOWN"
+    "$ICON_DOWN")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 10%- && $notify "Brightness Down $ICON_DOWN"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set -10% && $notify "Brightness Down $ICON_DOWN"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -dec 10 && $notify "Brightness Down $ICON_DOWN"
 		fi
         ;;
-    $ICON_OPT)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set 25% && $notify "Optimal Brightness $ICON_OPT"
+    "$ICON_OPT")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 25% && $notify "Optimal Brightness $ICON_OPT"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set 25% && $notify "Optimal Brightness $ICON_OPT"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -set 30 && $notify "Optimal Brightness $ICON_OPT"
 		fi

--- a/720p/applets/applets/backlight.sh
+++ b/720p/applets/applets/backlight.sh
@@ -16,7 +16,12 @@ msg() {
 }
 
 ## Get Brightness
-if [[ -f /usr/bin/blight ]]; then
+if [[ -f /bin/brightnessctl ]]; then
+	BNESS="$(brightnessctl get)"
+	MAX="$(brightnessctl max)"
+	PERC="$((BNESS*100/MAX))"
+	BLIGHT=${PERC%.*}
+elif [[ -f /usr/bin/blight ]]; then
 	DEVICE=$(ls /sys/class/backlight | head -n 1)
 	BNESS="$(blight -d $DEVICE get brightness)"
 	PERC="$(($BNESS*100/255))"
@@ -50,23 +55,29 @@ options="$ICON_UP\n$ICON_OPT\n$ICON_DOWN"
 ## Main
 chosen="$(echo -e "$options" | $rofi_command -p "$BLIGHT%" -dmenu -selected-row 1)"
 case $chosen in
-    $ICON_UP)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set +10% && $notify "Brightness Up $ICON_UP"
+    "$ICON_UP")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set +10% && $notify "Brightness Up $ICON_UP"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set +10% && $notify "Brightness Up $ICON_UP"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -inc 10 && $notify "Brightness Up $ICON_UP"
 		fi
         ;;
-    $ICON_DOWN)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set -10% && $notify "Brightness Down $ICON_DOWN"
+    "$ICON_DOWN")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 10%- && $notify "Brightness Down $ICON_DOWN"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set -10% && $notify "Brightness Down $ICON_DOWN"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -dec 10 && $notify "Brightness Down $ICON_DOWN"
 		fi
         ;;
-    $ICON_OPT)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set 25% && $notify "Optimal Brightness $ICON_OPT"
+    "$ICON_OPT")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 25% && $notify "Optimal Brightness $ICON_OPT"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set 25% && $notify "Optimal Brightness $ICON_OPT"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -set 30 && $notify "Optimal Brightness $ICON_OPT"
 		fi

--- a/720p/applets/menu/backlight.sh
+++ b/720p/applets/menu/backlight.sh
@@ -16,7 +16,12 @@ msg() {
 }
 
 ## Get Brightness
-if [[ -f /usr/bin/blight ]]; then
+if [[ -f /bin/brightnessctl ]]; then
+	BNESS="$(brightnessctl get)"
+	MAX="$(brightnessctl max)"
+	PERC="$((BNESS*100/MAX))"
+	BLIGHT=${PERC%.*}
+elif [[ -f /usr/bin/blight ]]; then
 	DEVICE=$(ls /sys/class/backlight | head -n 1)
 	BNESS="$(blight -d $DEVICE get brightness)"
 	PERC="$(($BNESS*100/255))"
@@ -50,23 +55,29 @@ options="$ICON_UP\n$ICON_OPT\n$ICON_DOWN"
 ## Main
 chosen="$(echo -e "$options" | $rofi_command -p "$BLIGHT%  :  $MSG" -dmenu -selected-row 1)"
 case $chosen in
-    $ICON_UP)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set +10% && $notify "Brightness Up $ICON_UP"
+    "$ICON_UP")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set +10% && $notify "Brightness Up $ICON_UP"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set +10% && $notify "Brightness Up $ICON_UP"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -inc 10 && $notify "Brightness Up $ICON_UP"
 		fi
         ;;
-    $ICON_DOWN)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set -10% && $notify "Brightness Down $ICON_DOWN"
+    "$ICON_DOWN")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 10%- && $notify "Brightness Down $ICON_DOWN"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set -10% && $notify "Brightness Down $ICON_DOWN"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -dec 10 && $notify "Brightness Down $ICON_DOWN"
 		fi
         ;;
-    $ICON_OPT)
-		if [[ -f /usr/bin/blight ]]; then
-			blight -d $DEVICE set 25% && $notify "Optimal Brightness $ICON_OPT"
+    "$ICON_OPT")
+		if [[ -f /bin/brightnessctl ]]; then
+			brightnessctl -q set 25% && $notify "Optimal Brightness $ICON_OPT"
+		elif [[ -f /usr/bin/blight ]]; then
+			blight -d "$DEVICE" set 25% && $notify "Optimal Brightness $ICON_OPT"
 		elif [[ -f /usr/bin/xbacklight ]]; then
 			xbacklight -set 30 && $notify "Optimal Brightness $ICON_OPT"
 		fi

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ ./setup.sh
 |Applets|Description|Supported / Required Applications|
 |:-|:-|:-|
 |**`Apps`**|Shortcuts for most used applications.|`termite`/`urxvt`/`kitty`/`xterm`, `thunar`/`pcmanfm`, `geany`/`leafpad`/`mousepad`/`code`, `firefox`/`chromium`/`midori`, etc|
-|**`Backlight`**|Display and adjust screen brightness.|`blight` and `xbacklight`|
+|**`Backlight`**|Display and adjust screen brightness.|`brightnessctl`, `blight` and `xbacklight`|
 |**`Battery`**|Display battery percentage & charging-discharging status with dynamic icons.|`acpi` and `xfce4-power-manager-settings`|
 |**`MPD`**|Control the song play through [mpd](https://github.com/MusicPlayerDaemon/).|`mpd`, `mpc` and `dunst`|
 |**`Network`**|Display Online-Offline status with dynamic icons.|`dnsutils`, `nmcli`, `nmtui`, `bmon`, `nm-connection-editor` and `termite`|


### PR DESCRIPTION
Hello :)
First, thanks a lot for those scripts and configs that make rofi even more awesome.

I'm using Fedora on a Dell laptop and the brightness setting doesn't work with either `xbacklight` nor `blight` but [`brightnessctl`](https://github.com/Hummer12007/brightnessctl)

So instead of keeping this tweak for myself, I thought that it would be better to share it with you in case other need to use the same utility as me.