### PR TITLE
Don't enforce sh, nitpicking about HOME variable

### DIFF
--- a/1080p/applets/applets/powermenu.sh
+++ b/1080p/applets/applets/powermenu.sh
@@ -11,8 +11,8 @@ dir="$HOME/.config/rofi/applets/applets/configs/$style"
 rofi_command="rofi -theme $dir/powermenu.rasi"
 
 uptime=$(uptime -p | sed -e 's/up //g')
-cpu=$(sh ~/.config/rofi/bin/usedcpu)
-memory=$(sh ~/.config/rofi/bin/usedram)
+cpu=$($HOME/.config/rofi/bin/usedcpu)
+memory=$($HOME/.config/rofi/bin/usedram)
 
 # Options
 shutdown=""

--- a/1080p/applets/menu/powermenu.sh
+++ b/1080p/applets/menu/powermenu.sh
@@ -11,8 +11,8 @@ dir="$HOME/.config/rofi/applets/menu/configs/$style"
 rofi_command="rofi -theme $dir/powermenu.rasi"
 
 uptime=$(uptime -p | sed -e 's/up //g')
-cpu=$(sh ~/.config/rofi/bin/usedcpu)
-memory=$(sh ~/.config/rofi/bin/usedram)
+cpu=$($HOME/.config/rofi/bin/usedcpu)
+memory=$($HOME/.config/rofi/bin/usedram)
 
 # Options
 shutdown=""

--- a/720p/applets/applets/powermenu.sh
+++ b/720p/applets/applets/powermenu.sh
@@ -11,8 +11,8 @@ dir="$HOME/.config/rofi/applets/applets/configs/$style"
 rofi_command="rofi -theme $dir/powermenu.rasi"
 
 uptime=$(uptime -p | sed -e 's/up //g')
-cpu=$(sh ~/.config/rofi/bin/usedcpu)
-memory=$(sh ~/.config/rofi/bin/usedram)
+cpu=$($HOME/.config/rofi/bin/usedcpu)
+memory=$($HOME/.config/rofi/bin/usedram)
 
 # Options
 shutdown=""

--- a/720p/applets/menu/powermenu.sh
+++ b/720p/applets/menu/powermenu.sh
@@ -11,8 +11,8 @@ dir="$HOME/.config/rofi/applets/menu/configs/$style"
 rofi_command="rofi -theme $dir/powermenu.rasi"
 
 uptime=$(uptime -p | sed -e 's/up //g')
-cpu=$(sh ~/.config/rofi/bin/usedcpu)
-memory=$(sh ~/.config/rofi/bin/usedram)
+cpu=$($HOME/.config/rofi/bin/usedcpu)
+memory=$($HOME/.config/rofi/bin/usedram)
 
 # Options
 shutdown=""


### PR DESCRIPTION
 * on some distributions sh is *not* bash, so don't enforce sh
 * it's not neccessarey to call the scripts with a shell because the
   permissions allow for direct execution
 * nitpicking: every part uses $HOME, so change ~ to $HOME for some
   calls