### PR TITLE
Added a minimal list like one-dark based rofi theme

### DIFF
--- a/720p/launchers/misc/minimal_list.rasi
+++ b/720p/launchers/misc/minimal_list.rasi
@@ -1,0 +1,30 @@
+configuration {
+	modi: "window,run,ssh,drun";
+	font: "Jetbrains Mono 13";
+	icon-theme: "Papirus";
+	show-icons: true;
+}
+
+* {
+	background-color: #282c34;
+	text-color: #abb2bf;
+	border: 0.5% 0.25% 0.5% 0.25%;
+	border-color: #282c34;
+	location: center;
+}
+
+prompt {
+	enabled: true;
+	padding: 0% 0.5% 0% 0%;
+	font: "Jetbrains Mono";
+	text-color: #abb2bf;
+	background-color: #282c34;
+}
+
+element-icon {
+	size: 25px;
+}
+
+element selected {
+	text-color: #98c379;
+}


### PR DESCRIPTION
Hello @adi1090x !

I added a One Dark based minimal list like Rofi Theme.

![my_rofi](https://user-images.githubusercontent.com/43932047/135670002-25d51186-0715-48e6-93b1-37744399ab2b.jpg)

The selected item is highlighted with green.
* Font: [JetBrains Mono](https://archlinux.org/packages/community/any/ttf-jetbrains-mono/)
*  Icons: [Papirus](https://archlinux.org/packages/community/any/papirus-icon-theme/)

I hope you like it!
Also, I'd appreciate it if you could add a ``hacktoberfest-accepted`` tag to this Pull Request. :smile: 

Kind Regards,
Shreyas