### PR TITLE
Add tokyonight color scheme

### DIFF
--- a/files/colors/tokyonight.rasi
+++ b/files/colors/tokyonight.rasi
@@ -1,0 +1,16 @@
+/**
+ *
+ * Author : Levi Lacoss (fishyfishfish55)
+ * Github : @fishyfishfish55
+ *
+ * Colors
+ **/
+
+* {
+    background:     #15161EFF;
+    background-alt: #1A1B26FF;
+    foreground:     #C0CAF5FF;
+    selected:       #33467CFF;
+    active:         #414868FF;
+    urgent:         #F7768EFF;
+}


### PR DESCRIPTION
While many color schemes are included in the repository, the popular theme [Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) seems to be missing. This adds the Tokyo Night color scheme.