### PR TITLE
Fixed parsing error: Invalid property name

### DIFF
--- a/files/config.rasi
+++ b/files/config.rasi
@@ -51,10 +51,13 @@ configuration {
 	run-shell-command: "{terminal} -e {cmd}";
 
 	/*---------- Fallback Icon ----------*/
-	run,drun {
+	run {
 		fallback-icon: "application-x-addon";
 	}
 
+	drun {
+		fallback-icon: "application-x-addon";
+	}
 	/*---------- Window switcher settings ----------*/
 	window-match-fields: "title,class,role,name,desktop";
 	window-command: "wmctrl -i -R {window}";


### PR DESCRIPTION
Separated the `run,drun {...}` into `run {...}    drun {...}`, as it was returning a parsing error. 

After running the `bash setup.sh`, when trying to open rofi, it would have the parsing error.