### PR TITLE
Change typo

### DIFF
--- a/files/config.rasi
+++ b/files/config.rasi
@@ -51,7 +51,7 @@ configuration {
 	run-shell-command: "{terminal} -e {cmd}";
 
 	/*---------- Fallback Icon ----------*/
-	run,drun {
+	run-drun {
 		fallback-icon: "application-x-addon";
 	}
 


### PR DESCRIPTION
When using this file i got an error when executing the launcher.sh. This error indicates that the config file couldn't be parsed. This is changed now with this commit.