### PR TITLE
Fixed Type-2 Sytle-2 theming

### DIFF
--- a/files/launchers/type-2/style-2.rasi
+++ b/files/launchers/type-2/style-2.rasi
@@ -134,6 +134,10 @@ element normal.normal {
     background-color:            @background;
     text-color:                  @foreground;
 }
+element alternate.normal {
+    background-color:            @background;
+    text-color:                  @foreground;
+}
 element selected.normal {
     background-color:            @selected;
     text-color:                  @background;


### PR DESCRIPTION
On the Type-2 Sytle-2 the 'element alternate.normal' is missing, causing every other program to have no theming