### PR TITLE
Add xsel case for session locking

### DIFF
--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -99,6 +99,8 @@ case ${chosen} in
 			betterlockscreen -l
 		elif [[ -x '/usr/bin/i3lock' ]]; then
 			i3lock
+		elif [[ -x '/usr/bin/xsel' ]]; then
+      xset s activate
 		fi
         ;;
     $suspend)

--- a/files/powermenu/type-2/powermenu.sh
+++ b/files/powermenu/type-2/powermenu.sh
@@ -100,6 +100,8 @@ case ${chosen} in
 			betterlockscreen -l
 		elif [[ -x '/usr/bin/i3lock' ]]; then
 			i3lock
+		elif [[ -x '/usr/bin/xsel' ]]; then
+      xset s activate
 		fi
         ;;
     $suspend)

--- a/files/powermenu/type-3/powermenu.sh
+++ b/files/powermenu/type-3/powermenu.sh
@@ -94,6 +94,8 @@ case ${chosen} in
 			betterlockscreen -l
 		elif [[ -x '/usr/bin/i3lock' ]]; then
 			i3lock
+		elif [[ -x '/usr/bin/xsel' ]]; then
+      xset s activate
 		fi
         ;;
     $suspend)

--- a/files/powermenu/type-4/powermenu.sh
+++ b/files/powermenu/type-4/powermenu.sh
@@ -94,6 +94,8 @@ case ${chosen} in
 			betterlockscreen -l
 		elif [[ -x '/usr/bin/i3lock' ]]; then
 			i3lock
+		elif [[ -x '/usr/bin/xsel' ]]; then
+      xset s activate
 		fi
         ;;
     $suspend)

--- a/files/powermenu/type-5/powermenu.sh
+++ b/files/powermenu/type-5/powermenu.sh
@@ -106,6 +106,8 @@ case ${chosen} in
 			betterlockscreen -l
 		elif [[ -x '/usr/bin/i3lock' ]]; then
 			i3lock
+		elif [[ -x '/usr/bin/xsel' ]]; then
+      xset s activate
 		fi
         ;;
     $suspend)

--- a/files/powermenu/type-6/powermenu.sh
+++ b/files/powermenu/type-6/powermenu.sh
@@ -106,6 +106,8 @@ case ${chosen} in
 			betterlockscreen -l
 		elif [[ -x '/usr/bin/i3lock' ]]; then
 			i3lock
+		elif [[ -x '/usr/bin/xsel' ]]; then
+      xset s activate
 		fi
         ;;
     $suspend)


### PR DESCRIPTION
Although `betterlockscreen` and `i3lock` are well known session lockers, I think that adding the case of X session lock via `xsel s activate` is a good option. Thanks.