### PR TITLE
set aboslute path to parent of setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ BBlack='\033[1;30m' BRed='\033[1;31m'    BGreen='\033[1;32m' BYellow='\033[1;33m
 BBlue='\033[1;34m'  BPurple='\033[1;35m' BCyan='\033[1;36m'  BWhite='\033[1;37m'
 
 ## Directories ----------------------------
-DIR=`pwd`
+DIR=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
 FONT_DIR="$HOME/.local/share/fonts"
 ROFI_DIR="$HOME/.config/rofi"
 

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ BBlack='\033[1;30m' BRed='\033[1;31m'    BGreen='\033[1;32m' BYellow='\033[1;33m
 BBlue='\033[1;34m'  BPurple='\033[1;35m' BCyan='\033[1;36m'  BWhite='\033[1;37m'
 
 ## Directories ----------------------------
-DIR=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 FONT_DIR="$HOME/.local/share/fonts"
 ROFI_DIR="$HOME/.config/rofi"
 


### PR DESCRIPTION
fixes #125

---

before:

```shell
> pwd
/home/me/Projects/Mine/Github/Dotfiles

> git clone --depth=1 https://github.com/adi1090x/rofi.git ./windowmanagers/files/rofi

> ./windowmanagers/files/rofi/setup.sh

[*] Installing fonts... 
cp: cannot stat '/home/me/Projects/Mine/Github/Dotfiles/fonts/*': No such file or directory
[*] Updating font cache...
 
[*] Creating a backup of your rofi configs... 
[*] Installing rofi configs... 
cp: cannot stat '/home/me/Projects/Mine/Github/Dotfiles/files/*': No such file or directory
[!] Failed to install.
 
```

after: 

```shell
> ./windowmanagers/files/rofi/setup.sh                                               

[*] Installing fonts... 
[*] Updating font cache...
 
[*] Creating a backup of your rofi configs... 
[*] Installing rofi configs... 
[*] Successfully Installed.
```


--- 

https://stackoverflow.com/a/9107028