### PR TITLE
Update fonts XDG variables

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ BBlue='\033[1;34m'  BPurple='\033[1;35m' BCyan='\033[1;36m'  BWhite='\033[1;37m'
 
 ## Directories ----------------------------
 DIR=`pwd`
-FONT_DIR="$HOME/.local/share/fonts"
+FONT_DIR="$XDG_DATA_HOME/fonts" # or $XDG_CONFIG_HOME
 ROFI_DIR="$HOME/.config/rofi"
 
 # Install Fonts
@@ -25,7 +25,7 @@ install_fonts() {
 		cp -rf $DIR/fonts/* "$FONT_DIR"
 	fi
 	echo -e ${BYellow}"[*] Updating font cache...\n" ${Color_Off}
-	fc-cache
+	fc-cache -r
 }
 
 # Install Themes


### PR DESCRIPTION
You have been installing themes and other things in `$XDG_CONFIG_HOME` directory like `ROFI_DIR="$HOME/.config/rofi"` (in `.config`), but fonts installed in `.local/shares/fonts`. I think that should be improved because this path is obsolete now for many applications, even `fc-cache` prefers `$XDG_DATA_HOME` (@see `/etc/fonts/fonts.conf` for more information).

Also, I added `-r, --really-force erase all existing caches, then rescan` argument, to verify the cache to be cleaned.