### PR TITLE
Fix handling of directory paths containing spaces in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,37 +11,37 @@ BBlack='\033[1;30m' BRed='\033[1;31m'    BGreen='\033[1;32m' BYellow='\033[1;33m
 BBlue='\033[1;34m'  BPurple='\033[1;35m' BCyan='\033[1;36m'  BWhite='\033[1;37m'
 
 ## Directories ----------------------------
-DIR=`pwd`
+DIR="$(pwd)"
 FONT_DIR="$HOME/.local/share/fonts"
 ROFI_DIR="$HOME/.config/rofi"
 
 # Install Fonts
 install_fonts() {
-	echo -e ${BBlue}"\n[*] Installing fonts..." ${Color_Off}
+	echo -e "${BBlue}\n[*] Installing fonts..." "${Color_Off}"
 	if [[ -d "$FONT_DIR" ]]; then
-		cp -rf $DIR/fonts/* "$FONT_DIR"
+		cp -rf "$DIR/fonts/"* "$FONT_DIR"
 	else
 		mkdir -p "$FONT_DIR"
-		cp -rf $DIR/fonts/* "$FONT_DIR"
+		cp -rf "$DIR/fonts/"* "$FONT_DIR"
 	fi
-	echo -e ${BYellow}"[*] Updating font cache...\n" ${Color_Off}
+	echo -e "${BYellow}[*] Updating font cache...\n" "${Color_Off}"
 	fc-cache
 }
 
 # Install Themes
 install_themes() {
 	if [[ -d "$ROFI_DIR" ]]; then
-		echo -e ${BPurple}"[*] Creating a backup of your rofi configs..." ${Color_Off}
+		echo -e "${BPurple}[*] Creating a backup of your rofi configs..." "${Color_Off}"
 		mv "$ROFI_DIR" "${ROFI_DIR}.${USER}"
 	fi
-	echo -e ${BBlue}"[*] Installing rofi configs..." ${Color_Off}
-	{ mkdir -p "$ROFI_DIR"; cp -rf $DIR/files/* "$ROFI_DIR"; }
+	echo -e "${BBlue}[*] Installing rofi configs..." "${Color_Off}"
+	{ mkdir -p "$ROFI_DIR"; cp -rf "$DIR/files/"* "$ROFI_DIR"; }
 
 	if [[ -f "$ROFI_DIR/config.rasi" ]]; then
-		echo -e ${BGreen}"[*] Successfully Installed.\n" ${Color_Off}
+		echo -e "${BGreen}[*] Successfully Installed.\n" "${Color_Off}"
 		exit 0
 	else
-		echo -e ${BRed}"[!] Failed to install.\n" ${Color_Off}
+		echo -e "${BRed}[!] Failed to install.\n" "${Color_Off}"
 		exit 1
 	fi
 }


### PR DESCRIPTION


Fixed an issue causing the setup script to throw an error/fail if the current working directory contains any spaces.

This was the error I got when I initially ran the setup from my `/Git Repo Clones` folder:

```
┌─[mt@archdt] ~ [/home/mt/CODE/Git Repo Clones/rofi]
└─ >> <git:(master 1dabf36✱) > ./setup.sh 

[*] Installing fonts... 
    /home/mt/CODE/Git Repo Clones/rofi (y/n): ^[[Acp: cannot stat '/home/mt/CODE/Git': No such file or directory
cp: cannot stat 'Repo': No such file or directory
cp: cannot stat 'Clones/rofi/fonts/*': No such file or directory
[*] Updating font cache...
 
[*] Creating a backup of your rofi configs... 
[*] Installing rofi configs... 
cp: cannot stat '/home/mt/CODE/Git': No such file or directory
cp: cannot stat 'Repo': No such file or directory
cp: cannot stat 'Clones/rofi/files/*': No such file or directory
[!] Failed to install.
```

After applying these changes, all dir path characters are preserved throughout the script execution and the installation works as intended.
