### PR TITLE
Fix 'config.rasi' file

### DIFF
--- a/files/config.rasi
+++ b/files/config.rasi
@@ -51,7 +51,7 @@ configuration {
 	run-shell-command: "{terminal} -e {cmd}";
 
 	/*---------- Fallback Icon ----------*/
-	run,drun {
+	run-drun {
 		fallback-icon: "application-x-addon";
 	}
 


### PR DESCRIPTION
Fix typo in 'config.rasi' that crashs the application after installation