### PR TITLE
Update config.rasi for Error while Parsing theme

### DIFF
--- a/files/config.rasi
+++ b/files/config.rasi
@@ -51,7 +51,7 @@ configuration {
 	run-shell-command: "{terminal} -e {cmd}";
 
 	/*---------- Fallback Icon ----------*/
-	run,drun {
+	run,drun: {
 		fallback-icon: "application-x-addon";
 	}
 


### PR DESCRIPTION
missing ":" in line 54 before "{" which led to error in parsing theme after installing using "./setup.sh" from Github clone.