### PR TITLE
Update config.rasi for Error while Parsing theme

### DIFF
--- a/files/config.rasi
+++ b/files/config.rasi
@@ -51,7 +51,7 @@ configuration {
 	run-shell-command: "{terminal} -e {cmd}";
 
 	/*---------- Fallback Icon ----------*/
-	run,drun {
+	run-drun {
 		fallback-icon: "application-x-addon";
 	}
 


### PR DESCRIPTION
Added "-" instead of "," in line 54 for "Error while parsing theme, parser error: syntax error, unexpected invalid property name  " after installing using "./setup.sh" from the git clone