### PR TITLE
Fixed syntax error in run-drun label

### DIFF
--- a/files/config.rasi
+++ b/files/config.rasi
@@ -51,7 +51,7 @@ configuration {
 	run-shell-command: "{terminal} -e {cmd}";
 
 	/*---------- Fallback Icon ----------*/
-	run,drun {
+	run-drun {
 		fallback-icon: "application-x-addon";
 	}
 


### PR DESCRIPTION
Corrected syntax error causing line 54 from run,drun to run-drun. Fixes syntax errors in launcher type-2 styles