### PR TITLE
Make CLI instructions copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@
 
 - Then, Clone this repository -
 ```
-$ git clone --depth=1 https://github.com/adi1090x/rofi.git
+git clone --depth=1 https://github.com/adi1090x/rofi.git
 ```
 
 - Change to cloned directory and make `setup.sh` executable -
 ```
-$ cd rofi
-$ chmod +x setup.sh
+cd rofi
+chmod +x setup.sh
 ```
 
 - Run `setup.sh` to install the configs -
 ```
-$ ./setup.sh
+./setup.sh
 
 [*] Installing fonts...
 [*] Updating font cache...


### PR DESCRIPTION
Currently, when hitting the copy button on the CLI instructions the leading `$ ` is included, which means you can't just paste and run the command. Instead, you have to manually remove the $, which is annoying. See screenshot:

![image](https://github.com/adi1090x/rofi/assets/43008483/898d79f5-8ae2-40a8-be10-e9de13b8b647)

PS: I like the themes. Thanks for sharing.