### PR TITLE
Use relative paths and more portable commands

### DIFF
--- a/files/applets/bin/appasroot.sh
+++ b/files/applets/bin/appasroot.sh
@@ -6,26 +6,10 @@
 ## Applets : Run Applications as Root
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 # Theme Elements
 prompt='Applications'

--- a/files/applets/bin/appasroot.sh
+++ b/files/applets/bin/appasroot.sh
@@ -6,7 +6,7 @@
 ## Applets : Run Applications as Root
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Theme Elements

--- a/files/applets/bin/appasroot.sh
+++ b/files/applets/bin/appasroot.sh
@@ -6,19 +6,24 @@
 ## Applets : Run Applications as Root
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/appasroot.sh
+++ b/files/applets/bin/appasroot.sh
@@ -6,8 +6,21 @@
 ## Applets : Run Applications as Root
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
 
 # Theme Elements
 prompt='Applications'

--- a/files/applets/bin/apps.sh
+++ b/files/applets/bin/apps.sh
@@ -6,26 +6,10 @@
 ## Applets : Favorite Applications
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 
 # Theme Elements
@@ -41,12 +25,12 @@ elif [[ ( "$theme" == *'type-2'* ) || ( "$theme" == *'type-4'* ) ]]; then
 fi
 
 # CMDs (add your apps here)
-term_cmd='alacritty'
-file_cmd='thunar'
-text_cmd='geany'
-web_cmd='firefox'
-music_cmd='alacritty -e ncmpcpp'
-setting_cmd='xfce4-settings-manager'
+term_cmd="${TERMINAL_CMD:-alacritty}"
+file_cmd="${FILE_BROWSER_CMD:-thunar}"
+text_cmd="${TEXT_EDITOR_CMD:-geany}"
+web_cmd="${WEB_BROWSER_CMD:-firefox}"
+music_cmd="${MUSIC_CMD:-alacritty -e ncmpcpp}"
+setting_cmd="${SETTINGS_CMD:-xfce4-settings-manager}"
 
 # Options
 layout=`cat ${theme} | grep 'USE_ICON' | cut -d'=' -f2`

--- a/files/applets/bin/apps.sh
+++ b/files/applets/bin/apps.sh
@@ -6,8 +6,22 @@
 ## Applets : Favorite Applications
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # Theme Elements
 prompt='Applications'

--- a/files/applets/bin/apps.sh
+++ b/files/applets/bin/apps.sh
@@ -6,19 +6,24 @@
 ## Applets : Favorite Applications
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/apps.sh
+++ b/files/applets/bin/apps.sh
@@ -6,7 +6,7 @@
 ## Applets : Favorite Applications
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Theme Elements

--- a/files/applets/bin/battery.sh
+++ b/files/applets/bin/battery.sh
@@ -6,27 +6,10 @@
 ## Applets : Battery
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
-
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 # Battery Info
 battery="`acpi -b | cut -d',' -f1 | cut -d':' -f1`"

--- a/files/applets/bin/battery.sh
+++ b/files/applets/bin/battery.sh
@@ -6,19 +6,24 @@
 ## Applets : Battery
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/battery.sh
+++ b/files/applets/bin/battery.sh
@@ -6,8 +6,22 @@
 ## Applets : Battery
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # Battery Info
 battery="`acpi -b | cut -d',' -f1 | cut -d':' -f1`"

--- a/files/applets/bin/battery.sh
+++ b/files/applets/bin/battery.sh
@@ -6,7 +6,7 @@
 ## Applets : Battery
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Battery Info

--- a/files/applets/bin/brightness.sh
+++ b/files/applets/bin/brightness.sh
@@ -6,26 +6,10 @@
 ## Applets : Brightness
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 # Brightness Info
 backlight="$(printf "%.0f\n" `light -G`)"

--- a/files/applets/bin/brightness.sh
+++ b/files/applets/bin/brightness.sh
@@ -6,19 +6,24 @@
 ## Applets : Brightness
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/brightness.sh
+++ b/files/applets/bin/brightness.sh
@@ -6,8 +6,21 @@
 ## Applets : Brightness
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
 
 # Brightness Info
 backlight="$(printf "%.0f\n" `light -G`)"

--- a/files/applets/bin/brightness.sh
+++ b/files/applets/bin/brightness.sh
@@ -6,7 +6,7 @@
 ## Applets : Brightness
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Brightness Info

--- a/files/applets/bin/mpd.sh
+++ b/files/applets/bin/mpd.sh
@@ -6,26 +6,10 @@
 ## Applets : MPD (music)
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 
 # Theme Elements

--- a/files/applets/bin/mpd.sh
+++ b/files/applets/bin/mpd.sh
@@ -6,7 +6,7 @@
 ## Applets : MPD (music)
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Theme Elements

--- a/files/applets/bin/mpd.sh
+++ b/files/applets/bin/mpd.sh
@@ -6,19 +6,24 @@
 ## Applets : MPD (music)
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/mpd.sh
+++ b/files/applets/bin/mpd.sh
@@ -6,8 +6,22 @@
 ## Applets : MPD (music)
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # Theme Elements
 status="`mpc status`"

--- a/files/applets/bin/powermenu.sh
+++ b/files/applets/bin/powermenu.sh
@@ -6,31 +6,17 @@
 ## Applets : Power Menu
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
-
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 # Theme Elements
 prompt="`hostname`"
-mesg="Uptime : `uptime -p | sed -e 's/up //g'`"
+
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
+
+mesg="Uptime : $uptime"
 
 if [[ ( "$theme" == *'type-1'* ) || ( "$theme" == *'type-3'* ) || ( "$theme" == *'type-5'* ) ]]; then
 	list_col='1'

--- a/files/applets/bin/powermenu.sh
+++ b/files/applets/bin/powermenu.sh
@@ -6,7 +6,7 @@
 ## Applets : Power Menu
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Theme Elements

--- a/files/applets/bin/powermenu.sh
+++ b/files/applets/bin/powermenu.sh
@@ -6,19 +6,24 @@
 ## Applets : Power Menu
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/powermenu.sh
+++ b/files/applets/bin/powermenu.sh
@@ -6,8 +6,22 @@
 ## Applets : Power Menu
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # Theme Elements
 prompt="`hostname`"

--- a/files/applets/bin/quicklinks.sh
+++ b/files/applets/bin/quicklinks.sh
@@ -6,26 +6,10 @@
 ## Applets : Quick Links
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 # Theme Elements
 prompt='Quick Links'

--- a/files/applets/bin/quicklinks.sh
+++ b/files/applets/bin/quicklinks.sh
@@ -6,7 +6,7 @@
 ## Applets : Quick Links
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Theme Elements

--- a/files/applets/bin/quicklinks.sh
+++ b/files/applets/bin/quicklinks.sh
@@ -6,8 +6,21 @@
 ## Applets : Quick Links
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
 
 # Theme Elements
 prompt='Quick Links'

--- a/files/applets/bin/quicklinks.sh
+++ b/files/applets/bin/quicklinks.sh
@@ -6,19 +6,24 @@
 ## Applets : Quick Links
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/screenshot.sh
+++ b/files/applets/bin/screenshot.sh
@@ -6,27 +6,10 @@
 ## Applets : Screenshot
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
-
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 # Theme Elements
 prompt='Screenshot'

--- a/files/applets/bin/screenshot.sh
+++ b/files/applets/bin/screenshot.sh
@@ -6,7 +6,7 @@
 ## Applets : Screenshot
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Theme Elements

--- a/files/applets/bin/screenshot.sh
+++ b/files/applets/bin/screenshot.sh
@@ -6,8 +6,22 @@
 ## Applets : Screenshot
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # Theme Elements
 prompt='Screenshot'

--- a/files/applets/bin/screenshot.sh
+++ b/files/applets/bin/screenshot.sh
@@ -6,19 +6,24 @@
 ## Applets : Screenshot
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/bin/volume.sh
+++ b/files/applets/bin/volume.sh
@@ -6,26 +6,10 @@
 ## Applets : Volume
 
 # Import Current Theme
+SCRIPT_INVOCATION="$0"
 INPUT_THEME="$1"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z "$INPUT_THEME" ]; then
-    source "$SCRIPT_DIR/../shared/theme.bash"
-    theme="$type/$style"
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [theme]"
-    exit 0
-else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; 
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-    fi
-fi
+source "$SCRIPT_DIR/../shared/theme.bash"
 
 
 # Volume Info

--- a/files/applets/bin/volume.sh
+++ b/files/applets/bin/volume.sh
@@ -6,7 +6,7 @@
 ## Applets : Volume
 
 # Import Current Theme
-source "$HOME"/.config/rofi/applets/shared/theme.bash
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
 theme="$type/$style"
 
 # Volume Info

--- a/files/applets/bin/volume.sh
+++ b/files/applets/bin/volume.sh
@@ -6,8 +6,22 @@
 ## Applets : Volume
 
 # Import Current Theme
-source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
-theme="$type/$style"
+INPUT_THEME=$1  
+
+if [ -z $INPUT_THEME ]; then
+    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+    theme="$type/$style"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [theme]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d $theme ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # Volume Info
 mixer="`amixer info Master | grep 'Mixer name' | cut -d':' -f2 | tr -d \',' '`"

--- a/files/applets/bin/volume.sh
+++ b/files/applets/bin/volume.sh
@@ -6,19 +6,24 @@
 ## Applets : Volume
 
 # Import Current Theme
-INPUT_THEME=$1  
-
-if [ -z $INPUT_THEME ]; then
-    source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../shared/theme.bash
+INPUT_THEME="$1"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+if [ -z "$INPUT_THEME" ]; then
+    source "$SCRIPT_DIR/../shared/theme.bash"
     theme="$type/$style"
 elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $0 [theme]"
     exit 0
 else
-    theme=$INPUT_THEME 
-    if [ ! -d $theme ]; then
-        echo "Theme not found!"
-        exit 1
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; 
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
     fi
 fi
 

--- a/files/applets/shared/colors.rasi
+++ b/files/applets/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "../../../colors/onedark.rasi"
+@import "../../colors/onedark.rasi"

--- a/files/applets/shared/colors.rasi
+++ b/files/applets/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/applets/shared/theme.bash
+++ b/files/applets/shared/theme.bash
@@ -1,4 +1,4 @@
 ## Current Theme
 
-type="$HOME/.config/rofi/applets/type-1"
+type="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../type-1
 style='style-1.rasi'

--- a/files/applets/shared/theme.bash
+++ b/files/applets/shared/theme.bash
@@ -2,8 +2,6 @@
 DEFAULT_TYPE='type-1'
 DEFAULT_STYLE='style-1'
 
-echo $SCRIPT_DIR
-
 # INPUT_THEME should be set by the script that sources this file, 
 # if the user wants to override the default theme.
 if [ -z "$INPUT_THEME" ]; then
@@ -12,15 +10,10 @@ elif [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage: $SCRIPT_INVOCATION [theme]"
     exit 0
 else
-    theme="$INPUT_THEME"
-    if [ ! -d $theme ]; then
-        # prepend current script path if theme is not found 
-        theme="$SCRIPT_DIR/../$theme"
-
-        if [ ! -d "$theme" ]; then
-          # fail if we still can't find it.
-          echo "Theme not found!"
-          exit 1
-        fi
+    theme="$SCRIPT_DIR/../$theme.rasi"
+    if [ ! -f "$theme" ]; then
+      # fail if we still can't find it.
+      echo "Theme not found!"
+      exit 1
     fi
 fi

--- a/files/applets/shared/theme.bash
+++ b/files/applets/shared/theme.bash
@@ -1,4 +1,26 @@
 ## Current Theme
+DEFAULT_TYPE='type-1'
+DEFAULT_STYLE='style-1'
 
-type="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/../type-1
-style='style-1.rasi'
+echo $SCRIPT_DIR
+
+# INPUT_THEME should be set by the script that sources this file, 
+# if the user wants to override the default theme.
+if [ -z "$INPUT_THEME" ]; then
+    theme="$SCRIPT_DIR/../$DEFAULT_TYPE/$DEFAULT_STYLE.rasi"
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $SCRIPT_INVOCATION [theme]"
+    exit 0
+else
+    theme="$INPUT_THEME"
+    if [ ! -d $theme ]; then
+        # prepend current script path if theme is not found 
+        theme="$SCRIPT_DIR/../$theme"
+
+        if [ ! -d "$theme" ]; then
+          # fail if we still can't find it.
+          echo "Theme not found!"
+          exit 1
+        fi
+    fi
+fi

--- a/files/applets/type-4/style-1.rasi
+++ b/files/applets/type-4/style-1.rasi
@@ -64,7 +64,7 @@ inputbar {
     border-radius:               0px;
     border-color:                @selected;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/a.png", width);
+    background-image:            url("./images/a.png", width);
     text-color:                  @foreground;
     children:                    [ "textbox-prompt-colon", "prompt"];
 }

--- a/files/applets/type-4/style-2.rasi
+++ b/files/applets/type-4/style-2.rasi
@@ -64,7 +64,7 @@ inputbar {
     border-radius:               20px;
     border-color:                @selected;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/d.png", width);
+    background-image:            url("./images/d.png", width);
     text-color:                  @foreground;
     children:                    [ "dummy", "textbox-prompt-colon", "prompt", "dummy"];
 }

--- a/files/applets/type-4/style-3.rasi
+++ b/files/applets/type-4/style-3.rasi
@@ -64,7 +64,7 @@ inputbar {
     border-radius:               40px;
     border-color:                @selected;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/i.jpg", width);
+    background-image:            url("./images/i.jpg", width);
     text-color:                  @foreground;
     children:                    [ "textbox-prompt-colon", "dummy", "prompt"];
 }

--- a/files/applets/type-5/style-1.rasi
+++ b/files/applets/type-5/style-1.rasi
@@ -59,7 +59,7 @@ mainbox {
 /*****----- Imagebox -----*****/
 imagebox {
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/e.jpg", height);
+    background-image:            url("./images/e.jpg", height);
     children:                    [ "dummy", "inputbar", "dummy" ];
 }
 

--- a/files/applets/type-5/style-2.rasi
+++ b/files/applets/type-5/style-2.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     border-radius:               20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/j.jpg", height);
+    background-image:            url("./images/j.jpg", height);
     children:                    [ "dummy", "inputbar", "dummy" ];
 }
 

--- a/files/applets/type-5/style-3.rasi
+++ b/files/applets/type-5/style-3.rasi
@@ -62,7 +62,7 @@ imagebox {
     border-radius:               100%;
     border-color:                @selected;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/g.png", height);
+    background-image:            url("./images/g.png", height);
     children:                    [ "dummy", "inputbar", "dummy" ];
 }
 

--- a/files/launchers/type-1/launcher.sh
+++ b/files/launchers/type-1/launcher.sh
@@ -11,8 +11,22 @@
 ## style-6     style-7     style-8     style-9     style-10
 ## style-11    style-12    style-13    style-14    style-15
 
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..15]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
+
 
 ## Run
 rofi \

--- a/files/launchers/type-1/launcher.sh
+++ b/files/launchers/type-1/launcher.sh
@@ -12,23 +12,15 @@
 ## style-11    style-12    style-13    style-14    style-15
 
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..15]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '15' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
-
-
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-1/launcher.sh
+++ b/files/launchers/type-1/launcher.sh
@@ -11,7 +11,7 @@
 ## style-6     style-7     style-8     style-9     style-10
 ## style-11    style-12    style-13    style-14    style-15
 
-dir="$HOME/.config/rofi/launchers/type-1"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 ## Run

--- a/files/launchers/type-1/shared/colors.rasi
+++ b/files/launchers/type-1/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/launchers/type-2/launcher.sh
+++ b/files/launchers/type-2/launcher.sh
@@ -11,8 +11,21 @@
 ## style-6     style-7     style-8     style-9     style-10
 ## style-11    style-12    style-13    style-14    style-15
 
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..15]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 ## Run
 rofi \

--- a/files/launchers/type-2/launcher.sh
+++ b/files/launchers/type-2/launcher.sh
@@ -11,7 +11,7 @@
 ## style-6     style-7     style-8     style-9     style-10
 ## style-11    style-12    style-13    style-14    style-15
 
-dir="$HOME/.config/rofi/launchers/type-2"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 ## Run

--- a/files/launchers/type-2/launcher.sh
+++ b/files/launchers/type-2/launcher.sh
@@ -12,22 +12,15 @@
 ## style-11    style-12    style-13    style-14    style-15
 
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..15]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
-fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '15' "$INPUT_THEME")
 
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
+fi
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-2/shared/colors.rasi
+++ b/files/launchers/type-2/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/launchers/type-3/launcher.sh
+++ b/files/launchers/type-3/launcher.sh
@@ -10,8 +10,21 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-10'
+if [ -z $INPUT_THEME ]; then
+    theme='style-10'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..10]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 ## Run
 rofi \

--- a/files/launchers/type-3/launcher.sh
+++ b/files/launchers/type-3/launcher.sh
@@ -11,22 +11,17 @@
 ## style-6     style-7     style-8     style-9     style-10
 
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-10'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..10]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '10' '10' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
+
 
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-3/launcher.sh
+++ b/files/launchers/type-3/launcher.sh
@@ -10,7 +10,7 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 
-dir="$HOME/.config/rofi/launchers/type-3"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-10'
 
 ## Run

--- a/files/launchers/type-3/shared/colors.rasi
+++ b/files/launchers/type-3/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/launchers/type-4/launcher.sh
+++ b/files/launchers/type-4/launcher.sh
@@ -9,9 +9,21 @@
 #
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
-
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..10]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 ## Run
 rofi \

--- a/files/launchers/type-4/launcher.sh
+++ b/files/launchers/type-4/launcher.sh
@@ -10,7 +10,7 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 
-dir="$HOME/.config/rofi/launchers/type-4"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 ## Run

--- a/files/launchers/type-4/launcher.sh
+++ b/files/launchers/type-4/launcher.sh
@@ -9,23 +9,17 @@
 #
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
-INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..10]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
-fi
 
+INPUT_THEME=$1  
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '10' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
+fi
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-4/shared/colors.rasi
+++ b/files/launchers/type-4/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/launchers/type-5/launcher.sh
+++ b/files/launchers/type-5/launcher.sh
@@ -8,9 +8,21 @@
 ## Available Styles
 #
 ## style-1     style-2     style-3     style-4     style-5
-
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..5]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 ## Run
 rofi \

--- a/files/launchers/type-5/launcher.sh
+++ b/files/launchers/type-5/launcher.sh
@@ -8,23 +8,17 @@
 ## Available Styles
 #
 ## style-1     style-2     style-3     style-4     style-5
-INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..5]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
-fi
 
+INPUT_THEME=$1  
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '5' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
+fi
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-5/launcher.sh
+++ b/files/launchers/type-5/launcher.sh
@@ -9,7 +9,7 @@
 #
 ## style-1     style-2     style-3     style-4     style-5
 
-dir="$HOME/.config/rofi/launchers/type-5"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 ## Run

--- a/files/launchers/type-5/style-1.rasi
+++ b/files/launchers/type-5/style-1.rasi
@@ -39,7 +39,7 @@ window {
     border-radius:               0px;
     border-color:                black;
     cursor:                      "default";
-    background-image:            url("~/.config/rofi/images/paper.png", none);
+    background-image:            url("./images/paper.png", none);
 }
 
 /*****----- Main Box -----*****/

--- a/files/launchers/type-5/style-2.rasi
+++ b/files/launchers/type-5/style-2.rasi
@@ -41,7 +41,7 @@ window {
     padding:                     0px;
     border-radius:               12px;
     cursor:                      "default";
-    background-image:            url("~/.config/rofi/images/gradient.png", width);
+    background-image:            url("./images/gradient.png", width);
 }
 
 /*****----- Main Box -----*****/

--- a/files/launchers/type-5/style-5.rasi
+++ b/files/launchers/type-5/style-5.rasi
@@ -42,7 +42,7 @@ window {
     border-radius:               20px;
     cursor:                      "default";
     background-color:            #162022;
-    background-image:            url("~/.config/rofi/images/flowers-1.png", width);
+    background-image:            url("./images/flowers-1.png", width);
 }
 
 /*****----- Main Box -----*****/
@@ -63,7 +63,7 @@ inputbar {
     border:                      2px;
     border-radius:               20px;
     border-color:                white;
-    background-image:            url("~/.config/rofi/images/flowers-3.png", none);
+    background-image:            url("./images/flowers-3.png", none);
     children:                    [ "textbox-prompt-colon", "entry" ];
 }
 
@@ -108,7 +108,7 @@ listview {
     border:                      2px;
     border-radius:               20px;
     border-color:                white;
-    background-image:            url("~/.config/rofi/images/flowers-2.png", width);
+    background-image:            url("./images/flowers-2.png", width);
     cursor:                      "default";
 }
 

--- a/files/launchers/type-6/launcher.sh
+++ b/files/launchers/type-6/launcher.sh
@@ -9,9 +9,21 @@
 #
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
-
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..10]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 ## Run
 rofi \

--- a/files/launchers/type-6/launcher.sh
+++ b/files/launchers/type-6/launcher.sh
@@ -10,7 +10,7 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 
-dir="$HOME/.config/rofi/launchers/type-6"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 ## Run

--- a/files/launchers/type-6/launcher.sh
+++ b/files/launchers/type-6/launcher.sh
@@ -10,22 +10,15 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..10]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
-fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '10' "$INPUT_THEME")
 
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
+fi
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-6/style-1.rasi
+++ b/files/launchers/type-6/style-1.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/a.png", height);
+    background-image:            url("./images/a.png", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-10.rasi
+++ b/files/launchers/type-6/style-10.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/j.jpg", height);
+    background-image:            url("./images/j.jpg", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-2.rasi
+++ b/files/launchers/type-6/style-2.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/b.png", height);
+    background-image:            url("./images/b.png", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-3.rasi
+++ b/files/launchers/type-6/style-3.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/c.png", height);
+    background-image:            url("./images/c.png", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-4.rasi
+++ b/files/launchers/type-6/style-4.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/d.png", height);
+    background-image:            url("./images/d.png", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-5.rasi
+++ b/files/launchers/type-6/style-5.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/e.jpg", height);
+    background-image:            url("./images/e.jpg", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-6.rasi
+++ b/files/launchers/type-6/style-6.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/f.png", height);
+    background-image:            url("./images/f.png", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-7.rasi
+++ b/files/launchers/type-6/style-7.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/g.png", height);
+    background-image:            url("./images/g.png", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-8.rasi
+++ b/files/launchers/type-6/style-8.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/h.jpg", height);
+    background-image:            url("./images/h.jpg", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-6/style-9.rasi
+++ b/files/launchers/type-6/style-9.rasi
@@ -60,7 +60,7 @@ mainbox {
 imagebox {
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/i.jpg", height);
+    background-image:            url("./images/i.jpg", height);
     orientation:                 vertical;
     children:                    [ "inputbar", "dummy", "mode-switcher" ];
 }

--- a/files/launchers/type-7/launcher.sh
+++ b/files/launchers/type-7/launcher.sh
@@ -9,9 +9,21 @@
 #
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
-
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..10]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 ## Run
 rofi \

--- a/files/launchers/type-7/launcher.sh
+++ b/files/launchers/type-7/launcher.sh
@@ -10,22 +10,15 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..10]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
-fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '10' "$INPUT_THEME")
 
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
+fi
 
 ## Run
 rofi \
     -show drun \
-    -theme ${dir}/${theme}.rasi
+    -theme $theme

--- a/files/launchers/type-7/launcher.sh
+++ b/files/launchers/type-7/launcher.sh
@@ -10,7 +10,7 @@
 ## style-1     style-2     style-3     style-4     style-5
 ## style-6     style-7     style-8     style-9     style-10
 
-dir="$HOME/.config/rofi/launchers/type-7"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 ## Run

--- a/files/launchers/type-7/style-1.rasi
+++ b/files/launchers/type-7/style-1.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     80px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/a.png", width);
+    background-image:            url("./images/a.png", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/launchers/type-7/style-10.rasi
+++ b/files/launchers/type-7/style-10.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     0px;
     padding:                     100px 40px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/j.jpg", width);
+    background-image:            url("./images/j.jpg", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry" ];

--- a/files/launchers/type-7/style-2.rasi
+++ b/files/launchers/type-7/style-2.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     80px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/b.png", width);
+    background-image:            url("./images/b.png", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/launchers/type-7/style-3.rasi
+++ b/files/launchers/type-7/style-3.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     100px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/c.png", width);
+    background-image:            url("./images/c.png", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/launchers/type-7/style-4.rasi
+++ b/files/launchers/type-7/style-4.rasi
@@ -72,7 +72,7 @@ inputbar {
     spacing:                     10px;
     padding:                     40px 40px 155px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/d.png", width);
+    background-image:            url("./images/d.png", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry" ];

--- a/files/launchers/type-7/style-5.rasi
+++ b/files/launchers/type-7/style-5.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     80px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/e.jpg", width);
+    background-image:            url("./images/e.jpg", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/launchers/type-7/style-6.rasi
+++ b/files/launchers/type-7/style-6.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     100px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/f.png", width);
+    background-image:            url("./images/f.png", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/launchers/type-7/style-7.rasi
+++ b/files/launchers/type-7/style-7.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     100px 40px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/g.png", width);
+    background-image:            url("./images/g.png", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry" ];

--- a/files/launchers/type-7/style-8.rasi
+++ b/files/launchers/type-7/style-8.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     100px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/h.jpg", width);
+    background-image:            url("./images/h.jpg", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/launchers/type-7/style-9.rasi
+++ b/files/launchers/type-7/style-9.rasi
@@ -71,7 +71,7 @@ inputbar {
     spacing:                     10px;
     padding:                     80px 60px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/i.jpg", width);
+    background-image:            url("./images/i.jpg", width);
     text-color:                  @foreground;
     orientation:                 horizontal;
     children:                    [ "textbox-prompt-colon", "entry", "dummy", "mode-switcher" ];

--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -27,7 +27,7 @@ fi
 
 
 # CMDs
-uptime="`uptime -p | sed -e 's/up //g'`"
+uptime=$($dir/../../shared/uptime.sh)
 host=`hostname`
 
 # Options

--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -10,8 +10,21 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..5]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # CMDs
 uptime="`uptime -p | sed -e 's/up //g'`"

--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -10,7 +10,7 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
-dir="$HOME/.config/rofi/powermenu/type-1"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 # CMDs

--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -9,25 +9,17 @@
 #
 ## style-1   style-2   style-3   style-4   style-5
 
-# Current Theme
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..5]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '5' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
 
-
 # CMDs
-uptime=$($dir/../../shared/uptime.sh)
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
 host=`hostname`
 
 # Options
@@ -44,7 +36,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p "$host" \
 		-mesg "Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Confirmation CMD
@@ -57,7 +49,7 @@ confirm_cmd() {
 		-dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Ask for confirmation

--- a/files/powermenu/type-1/shared/colors.rasi
+++ b/files/powermenu/type-1/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/powermenu/type-2/powermenu.sh
+++ b/files/powermenu/type-2/powermenu.sh
@@ -11,8 +11,21 @@
 ## style-6   style-7   style-8   style-9   style-10
 
 # Current Theme
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..10]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # CMDs
 uptime="`uptime -p | sed -e 's/up //g'`"

--- a/files/powermenu/type-2/powermenu.sh
+++ b/files/powermenu/type-2/powermenu.sh
@@ -28,7 +28,7 @@ fi
 
 
 # CMDs
-uptime="`uptime -p | sed -e 's/up //g'`"
+uptime=$($dir/../../shared/uptime.sh)
 host=`hostname`
 
 # Options

--- a/files/powermenu/type-2/powermenu.sh
+++ b/files/powermenu/type-2/powermenu.sh
@@ -11,7 +11,7 @@
 ## style-6   style-7   style-8   style-9   style-10
 
 # Current Theme
-dir="$HOME/.config/rofi/powermenu/type-2"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 # CMDs

--- a/files/powermenu/type-2/powermenu.sh
+++ b/files/powermenu/type-2/powermenu.sh
@@ -10,25 +10,17 @@
 ## style-1   style-2   style-3   style-4   style-5
 ## style-6   style-7   style-8   style-9   style-10
 
-# Current Theme
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..10]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '10' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
 
-
 # CMDs
-uptime=$($dir/../../shared/uptime.sh)
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
 host=`hostname`
 
 # Options
@@ -45,7 +37,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p "Uptime: $uptime" \
 		-mesg "Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Confirmation CMD
@@ -58,7 +50,7 @@ confirm_cmd() {
 		-dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Ask for confirmation

--- a/files/powermenu/type-2/shared/colors.rasi
+++ b/files/powermenu/type-2/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/powermenu/type-3/powermenu.sh
+++ b/files/powermenu/type-3/powermenu.sh
@@ -10,8 +10,21 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..10]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # CMDs
 uptime="`uptime -p | sed -e 's/up //g'`"

--- a/files/powermenu/type-3/powermenu.sh
+++ b/files/powermenu/type-3/powermenu.sh
@@ -27,7 +27,7 @@ fi
 
 
 # CMDs
-uptime="`uptime -p | sed -e 's/up //g'`"
+uptime=$($dir/../../shared/uptime.sh)
 host=`hostname`
 
 # Options

--- a/files/powermenu/type-3/powermenu.sh
+++ b/files/powermenu/type-3/powermenu.sh
@@ -9,25 +9,18 @@
 #
 ## style-1   style-2   style-3   style-4   style-5
 
-# Current Theme
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..10]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '5' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
 
 
 # CMDs
-uptime=$($dir/../../shared/uptime.sh)
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
 host=`hostname`
 
 # Options
@@ -44,7 +37,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p "Uptime: $uptime" \
 		-mesg "Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Confirmation CMD
@@ -52,7 +45,7 @@ confirm_cmd() {
 	rofi -dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/shared/confirm.rasi
+		-theme ${SCRIPT_DIR}/shared/confirm.rasi
 }
 
 # Ask for confirmation

--- a/files/powermenu/type-3/powermenu.sh
+++ b/files/powermenu/type-3/powermenu.sh
@@ -10,7 +10,7 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
-dir="$HOME/.config/rofi/powermenu/type-3"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 # CMDs

--- a/files/powermenu/type-3/shared/colors.rasi
+++ b/files/powermenu/type-3/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/powermenu/type-4/powermenu.sh
+++ b/files/powermenu/type-4/powermenu.sh
@@ -27,7 +27,7 @@ fi
 
 
 # CMDs
-uptime="`uptime -p | sed -e 's/up //g'`"
+uptime=$($dir/../../shared/uptime.sh)
 host=`hostname`
 
 # Options

--- a/files/powermenu/type-4/powermenu.sh
+++ b/files/powermenu/type-4/powermenu.sh
@@ -10,8 +10,21 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-5'
+if [ -z $INPUT_THEME ]; then
+    theme='style-5'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..5]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # CMDs
 uptime="`uptime -p | sed -e 's/up //g'`"

--- a/files/powermenu/type-4/powermenu.sh
+++ b/files/powermenu/type-4/powermenu.sh
@@ -10,7 +10,7 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
-dir="$HOME/.config/rofi/powermenu/type-4"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-5'
 
 # CMDs

--- a/files/powermenu/type-4/powermenu.sh
+++ b/files/powermenu/type-4/powermenu.sh
@@ -9,25 +9,19 @@
 #
 ## style-1   style-2   style-3   style-4   style-5
 
-# Current Theme
+
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-5'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..5]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '5' '5' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
 
 
 # CMDs
-uptime=$($dir/../../shared/uptime.sh)
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
 host=`hostname`
 
 # Options
@@ -44,7 +38,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p "Goodbye ${USER}" \
 		-mesg "Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Confirmation CMD
@@ -52,7 +46,7 @@ confirm_cmd() {
 	rofi -dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/shared/confirm.rasi
+		-theme ${SCRIPT_DIR}/shared/confirm.rasi
 }
 
 # Ask for confirmation

--- a/files/powermenu/type-4/shared/colors.rasi
+++ b/files/powermenu/type-4/shared/colors.rasi
@@ -15,4 +15,4 @@
 
 /* Import color-scheme from `colors` directory */
 
-@import "~/.config/rofi/colors/onedark.rasi"
+@import "../../../colors/onedark.rasi"

--- a/files/powermenu/type-4/style-5.rasi
+++ b/files/powermenu/type-4/style-5.rasi
@@ -83,7 +83,7 @@ userimage {
     border-radius:               100%;
     border-color:                white;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/user.jpeg", both);
+    background-image:            url("./images/user.jpeg", both);
 }
 
 /*****----- Inputbar -----*****/

--- a/files/powermenu/type-5/powermenu.sh
+++ b/files/powermenu/type-5/powermenu.sh
@@ -28,7 +28,7 @@ fi
 
 # CMDs
 lastlogin="`last $USER | head -n1 | tr -s ' ' | cut -d' ' -f5,6,7`"
-uptime="`uptime -p | sed -e 's/up //g'`"
+uptime=$($dir/../../shared/uptime.sh)
 host=`hostname`
 
 # Options

--- a/files/powermenu/type-5/powermenu.sh
+++ b/files/powermenu/type-5/powermenu.sh
@@ -10,8 +10,21 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..5]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # CMDs
 lastlogin="`last $USER | head -n1 | tr -s ' ' | cut -d' ' -f5,6,7`"

--- a/files/powermenu/type-5/powermenu.sh
+++ b/files/powermenu/type-5/powermenu.sh
@@ -9,26 +9,19 @@
 #
 ## style-1   style-2   style-3   style-4   style-5
 
-# Current Theme
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..5]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '5' "$INPUT_THEME")
+
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
 fi
 
 
 # CMDs
 lastlogin="`last $USER | head -n1 | tr -s ' ' | cut -d' ' -f5,6,7`"
-uptime=$($dir/../../shared/uptime.sh)
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
 host=`hostname`
 
 # Options
@@ -46,7 +39,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p " $USER@$host" \
 		-mesg " Last Login: $lastlogin |  Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Confirmation CMD
@@ -59,7 +52,7 @@ confirm_cmd() {
 		-dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Ask for confirmation

--- a/files/powermenu/type-5/powermenu.sh
+++ b/files/powermenu/type-5/powermenu.sh
@@ -10,7 +10,7 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
-dir="$HOME/.config/rofi/powermenu/type-5"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 # CMDs

--- a/files/powermenu/type-5/style-1.rasi
+++ b/files/powermenu/type-5/style-1.rasi
@@ -64,7 +64,7 @@ inputbar {
     spacing:                     0px;
     padding:                     100px 80px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/a.png", width);
+    background-image:            url("./images/a.png", width);
     children:                    [ "textbox-prompt-colon", "dummy","prompt"];
 }
 

--- a/files/powermenu/type-5/style-2.rasi
+++ b/files/powermenu/type-5/style-2.rasi
@@ -64,7 +64,7 @@ inputbar {
     spacing:                     0px;
     padding:                     100px 80px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/d.png", width);
+    background-image:            url("./images/d.png", width);
     children:                    [ "textbox-prompt-colon", "dummy","prompt"];
 }
 

--- a/files/powermenu/type-5/style-3.rasi
+++ b/files/powermenu/type-5/style-3.rasi
@@ -64,7 +64,7 @@ inputbar {
     spacing:                     0px;
     padding:                     100px 40px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/e.jpg", width);
+    background-image:            url("./images/e.jpg", width);
     children:                    [ "textbox-prompt-colon", "dummy","prompt"];
 }
 

--- a/files/powermenu/type-5/style-4.rasi
+++ b/files/powermenu/type-5/style-4.rasi
@@ -64,7 +64,7 @@ inputbar {
     spacing:                     0px;
     padding:                     150px 40px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/i.jpg", width);
+    background-image:            url("./images/i.jpg", width);
     children:                    [ "textbox-prompt-colon", "dummy","prompt"];
 }
 

--- a/files/powermenu/type-5/style-5.rasi
+++ b/files/powermenu/type-5/style-5.rasi
@@ -64,7 +64,7 @@ inputbar {
     spacing:                     20px;
     padding:                     100px 40px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/j.jpg", width);
+    background-image:            url("./images/j.jpg", width);
     children:                    [ "textbox-prompt-colon", "prompt"];
 }
 

--- a/files/powermenu/type-6/powermenu.sh
+++ b/files/powermenu/type-6/powermenu.sh
@@ -28,7 +28,7 @@ fi
 
 # CMDs
 lastlogin="`last $USER | head -n1 | tr -s ' ' | cut -d' ' -f5,6,7`"
-uptime="`uptime -p | sed -e 's/up //g'`"
+uptime=$($dir/../../shared/uptime.sh)
 host=`hostname`
 
 # Options

--- a/files/powermenu/type-6/powermenu.sh
+++ b/files/powermenu/type-6/powermenu.sh
@@ -10,8 +10,21 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
+INPUT_THEME=$1  
 dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-theme='style-1'
+if [ -z $INPUT_THEME ]; then
+    theme='style-1'
+elif [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage: $0 [style-1..5]"
+    exit 0
+else
+    theme=$INPUT_THEME 
+    if [ ! -d ${dir}/$theme.rasi ]; then
+        echo "Theme not found!"
+        exit 1
+    fi
+fi
+
 
 # CMDs
 lastlogin="`last $USER | head -n1 | tr -s ' ' | cut -d' ' -f5,6,7`"

--- a/files/powermenu/type-6/powermenu.sh
+++ b/files/powermenu/type-6/powermenu.sh
@@ -10,7 +10,7 @@
 ## style-1   style-2   style-3   style-4   style-5
 
 # Current Theme
-dir="$HOME/.config/rofi/powermenu/type-6"
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 theme='style-1'
 
 # CMDs

--- a/files/powermenu/type-6/powermenu.sh
+++ b/files/powermenu/type-6/powermenu.sh
@@ -9,26 +9,18 @@
 #
 ## style-1   style-2   style-3   style-4   style-5
 
-# Current Theme
 INPUT_THEME=$1  
-dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-if [ -z $INPUT_THEME ]; then
-    theme='style-1'
-elif [[ $1 == "-h" || $1 == "--help" ]]; then
-    echo "Usage: $0 [style-1..5]"
-    exit 0
-else
-    theme=$INPUT_THEME 
-    if [ ! -d ${dir}/$theme.rasi ]; then
-        echo "Theme not found!"
-        exit 1
-    fi
-fi
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+theme=$($SCRIPT_DIR/../../shared/theme.sh "$SCRIPT_DIR" '1' '5' "$INPUT_THEME")
 
+if [ $? -ne 0 ]; then
+    echo $theme
+    exit 1
+fi
 
 # CMDs
 lastlogin="`last $USER | head -n1 | tr -s ' ' | cut -d' ' -f5,6,7`"
-uptime=$($dir/../../shared/uptime.sh)
+uptime=$($SCRIPT_DIR/../../shared/uptime.sh)
 host=`hostname`
 
 # Options
@@ -46,7 +38,7 @@ rofi_cmd() {
 	rofi -dmenu \
 		-p " $USER@$host" \
 		-mesg " Uptime: $uptime" \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Confirmation CMD
@@ -59,7 +51,7 @@ confirm_cmd() {
 		-dmenu \
 		-p 'Confirmation' \
 		-mesg 'Are you Sure?' \
-		-theme ${dir}/${theme}.rasi
+		-theme $theme
 }
 
 # Ask for confirmation

--- a/files/powermenu/type-6/style-1.rasi
+++ b/files/powermenu/type-6/style-1.rasi
@@ -57,7 +57,7 @@ imagebox {
     spacing:                     30px;
     padding:                     30px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/a.png", height);
+    background-image:            url("./images/a.png", height);
     children:                    [ "inputbar", "dummy", "message" ];
 }
 
@@ -68,7 +68,7 @@ userimage {
     border-radius:               10px;
     border-color:                @background-alt;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/a.png", height);
+    background-image:            url("./images/a.png", height);
 }
 
 /*****----- Inputbar -----*****/

--- a/files/powermenu/type-6/style-2.rasi
+++ b/files/powermenu/type-6/style-2.rasi
@@ -57,7 +57,7 @@ imagebox {
     spacing:                     20px;
     padding:                     20px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/d.png", height);
+    background-image:            url("./images/d.png", height);
     children:                    [ "inputbar", "dummy", "message" ];
 }
 
@@ -68,7 +68,7 @@ userimage {
     border-radius:               10px;
     border-color:                @background-alt;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/d.png", height);
+    background-image:            url("./images/d.png", height);
 }
 
 /*****----- Inputbar -----*****/

--- a/files/powermenu/type-6/style-3.rasi
+++ b/files/powermenu/type-6/style-3.rasi
@@ -57,7 +57,7 @@ imagebox {
     spacing:                     0px;
     padding:                     30px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/e.jpg", width);
+    background-image:            url("./images/e.jpg", width);
     children:                    [ "inputbar", "dummy", "message" ];
 }
 
@@ -68,7 +68,7 @@ userimage {
     border-radius:               10px;
     border-color:                @background-alt;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/e.jpg", height);
+    background-image:            url("./images/e.jpg", height);
 }
 
 /*****----- Inputbar -----*****/

--- a/files/powermenu/type-6/style-4.rasi
+++ b/files/powermenu/type-6/style-4.rasi
@@ -59,7 +59,7 @@ imagebox {
     spacing:                     0px;
     padding:                     100px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/i.jpg", height);
+    background-image:            url("./images/i.jpg", height);
     children:                    [ "inputbar", "dummy", "message" ];
 }
 
@@ -70,7 +70,7 @@ userimage {
     border-radius:               0px;
     border-color:                @background-alt;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/i.jpg", height);
+    background-image:            url("./images/i.jpg", height);
 }
 
 /*****----- Inputbar -----*****/

--- a/files/powermenu/type-6/style-5.rasi
+++ b/files/powermenu/type-6/style-5.rasi
@@ -59,7 +59,7 @@ imagebox {
     spacing:                     0px;
     padding:                     100px;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/j.jpg", height);
+    background-image:            url("./images/j.jpg", height);
     children:                    [ "inputbar", "dummy", "message" ];
 }
 
@@ -70,7 +70,7 @@ userimage {
     border-radius:               0px;
     border-color:                @background-alt;
     background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/j.jpg", height);
+    background-image:            url("./images/j.jpg", height);
 }
 
 /*****----- Inputbar -----*****/

--- a/files/shared/theme.sh
+++ b/files/shared/theme.sh
@@ -6,7 +6,7 @@ MAX_THEME=$3
 INPUT_THEME=$4
 
 if [ -z "$INPUT_THEME" ]; then
-    theme="$DEFAULT_THEME"
+    theme="$SOURCE_DIR/style-$DEFAULT_THEME.rasi"
 elif [[ "$INPUT_THEME" == "-h" || "$INPUT_THEME" == "--help" ]]; then
     echo "Usage: $SOURCE_DIR [1..$MAX_THEME]"
     exit 1

--- a/files/shared/theme.sh
+++ b/files/shared/theme.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SOURCE_DIR=$1
+DEFAULT_THEME=$2
+MAX_THEME=$3
+INPUT_THEME=$4
+
+if [ -z "$INPUT_THEME" ]; then
+    theme="$DEFAULT_THEME"
+elif [[ "$INPUT_THEME" == "-h" || "$INPUT_THEME" == "--help" ]]; then
+    echo "Usage: $SOURCE_DIR [1..$MAX_THEME]"
+    exit 1
+elif [[ "$INPUT_THEME" -gt "$MAX_THEME" || "$INPUT_THEME" -lt 1 ]]; then
+    echo "Invalid theme number! Theme must be between 1 and $MAX_THEME"
+    exit 1
+else
+    theme="$SOURCE_DIR/style-$INPUT_THEME.rasi"
+    if [ ! -f "$theme" ]; then
+        echo "Theme not found at $theme"
+        exit 1
+    fi
+fi
+
+echo -n "$theme"

--- a/files/shared/uptime.sh
+++ b/files/shared/uptime.sh
@@ -1,21 +1,32 @@
 #!/usr/bin/env bash
 
-uptime_seconds=$(awk '{print $1}' /proc/uptime)
-echo -n $(awk -v UP="$uptime_seconds" '
-BEGIN {
-    days = int(UP / 86400);
-    hours = int((UP % 86400) / 3600);
-    minutes = int((UP % 3600) / 60);
-    seconds = int(UP % 60);
-    if (days > 0) {
-        if (days == 1) {
-            printf "1 day, %d hours, %d minutes\n", hours, minutes;
-        } else {
-            printf "%d days, %d hours, %d minutes\n", days, hours, minutes;
-        }
-    } else if (hours > 0) {
-        printf "%d hours, %d minutes\n", hours, minutes;
-    } else {
-        printf "%d minutes\n", minutes;
-    }
-}')
+uptime_seconds=$(cat /proc/uptime | sed 's/^\([0-9]\+\)\..*/\1/')
+
+# Format the uptime
+days=$(( uptime_seconds / 86400 ))
+hours=$(( (uptime_seconds % 86400) / 3600 ))
+minutes=$(( (uptime_seconds % 3600) / 60 ))
+
+# Helper function for pluralization
+pluralize() {
+  local value=$1
+  local singular=$2
+  local plural=$3
+  if [ "$value" -eq 1 ]; then
+    echo "$value $singular"
+  else
+    echo "$value $plural"
+  fi
+}
+
+# Construct the uptime string
+if [ "$days" -gt 0 ]; then
+  uptime="$(pluralize $days day days), $(pluralize $hours hour hours), $(pluralize $minutes minute minutes)"
+elif [ "$hours" -gt 0 ]; then
+  uptime="$(pluralize $hours hour hours), $(pluralize $minutes minute minutes)"
+else
+  uptime="$(pluralize $minutes minute minutes)"
+fi
+
+echo "$uptime"
+

--- a/files/shared/uptime.sh
+++ b/files/shared/uptime.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+uptime_seconds=$(awk '{print $1}' /proc/uptime)
+echo -n $(awk -v UP="$uptime_seconds" '
+BEGIN {
+    days = int(UP / 86400);
+    hours = int((UP % 86400) / 3600);
+    minutes = int((UP % 3600) / 60);
+    seconds = int(UP % 60);
+    if (days > 0) {
+        if (days == 1) {
+            printf "1 day, %d hours, %d minutes\n", hours, minutes;
+        } else {
+            printf "%d days, %d hours, %d minutes\n", days, hours, minutes;
+        }
+    } else if (hours > 0) {
+        printf "%d hours, %d minutes\n", hours, minutes;
+    } else {
+        printf "%d minutes\n", minutes;
+    }
+}')

--- a/setup.sh
+++ b/setup.sh
@@ -33,26 +33,27 @@ DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 # Install Fonts
 install_fonts() {
 	echo -e ${BBlue}"\n[*] Installing fonts to $FONT_DIR ${Color_Off}"
-	if [[ -d "$FONT_DIR" ]]; then
-		cp -rf $DIR/fonts/* "$FONT_DIR"
-	else
+
+	if [ ! -d "$FONT_DIR" ]; then
 		mkdir -p "$FONT_DIR"
-		cp -rf $DIR/fonts/* "$FONT_DIR"
 	fi
+
+	cp -rf $DIR/fonts/* "$FONT_DIR"
+
 	echo -e ${BYellow}"[*] Updating font cache" ${Color_Off}
 	fc-cache
 }
 
 # Install Themes
 install_themes() {
-	if [[ -d "$ROFI_DIR" ]]; then
-		echo -e ${BPurple}"[*] Creating a backup of your rofi configs in ${ROFI_DIR}.${USER}" ${Color_Off}
+	if [ -d "$ROFI_DIR" ]; then
+		echo -e ${BPurple}"[*] Creating a backup of your rofi configs in '${ROFI_DIR}.${USER}'" ${Color_Off}
 		mv "$ROFI_DIR" "${ROFI_DIR}.${USER}"
 	fi
-	echo -e ${BBlue}"[*] Installing rofi configs in $ROFI_DIR" ${Color_Off}
+	echo -e ${BBlue}"[*] Installing rofi configs in '$ROFI_DIR'" ${Color_Off}
 	{ mkdir -p "$ROFI_DIR"; cp -rf $DIR/files/* "$ROFI_DIR"; }
 
-	if [[ -f "$ROFI_DIR/config.rasi" ]]; then
+	if [ -f "$ROFI_DIR/config.rasi" ]; then
 		echo -e ${BGreen}"[*] Successfully Installed." ${Color_Off}
 		exit 0
 	else
@@ -63,9 +64,9 @@ install_themes() {
 
 # Main
 main() {
-	install_fonts
-    echo ""
 	install_themes
+    echo ""
+	install_fonts
     echo ""
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,38 +10,53 @@ Color_Off='\033[0m'
 BBlack='\033[1;30m' BRed='\033[1;31m'    BGreen='\033[1;32m' BYellow='\033[1;33m'
 BBlue='\033[1;34m'  BPurple='\033[1;35m' BCyan='\033[1;36m'  BWhite='\033[1;37m'
 
+
 ## Directories ----------------------------
-DIR=`pwd`
-FONT_DIR="$HOME/.local/share/fonts"
-ROFI_DIR="$HOME/.config/rofi"
+ROFI_INSTALL_DIR=$1 
+FONT_INSTALL_DIR=$2
+
+if [ -z "$ROFI_INSTALL_DIR" ]; then
+    ROFI_INSTALL_DIR="$HOME/.config/rofi"
+    FONT_DIR="$HOME/.local/share/fonts"
+    ROFI_DIR="$HOME/.config/rofi"
+else
+    if [ -z "$FONT_INSTALL_DIR" ]; then
+        FONT_DIR="$ROFI_INSTALL_DIR/fonts"
+    else
+        FONT_DIR="$FONT_INSTALL_DIR"
+    fi
+    ROFI_DIR="$ROFI_INSTALL_DIR"
+fi
+
+DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # Install Fonts
 install_fonts() {
-	echo -e ${BBlue}"\n[*] Installing fonts..." ${Color_Off}
+	echo -e ${BBlue}"\n[*] Installing fonts to $FONT_DIR ${Color_Off}"
 	if [[ -d "$FONT_DIR" ]]; then
 		cp -rf $DIR/fonts/* "$FONT_DIR"
 	else
 		mkdir -p "$FONT_DIR"
 		cp -rf $DIR/fonts/* "$FONT_DIR"
 	fi
-	echo -e ${BYellow}"[*] Updating font cache...\n" ${Color_Off}
+	echo -e ${BYellow}"[*] Updating font cache" ${Color_Off}
 	fc-cache
 }
 
 # Install Themes
 install_themes() {
 	if [[ -d "$ROFI_DIR" ]]; then
-		echo -e ${BPurple}"[*] Creating a backup of your rofi configs..." ${Color_Off}
+		echo -e ${BPurple}"[*] Creating a backup of your rofi configs in ${ROFI_DIR}.${USER}" ${Color_Off}
 		mv "$ROFI_DIR" "${ROFI_DIR}.${USER}"
 	fi
-	echo -e ${BBlue}"[*] Installing rofi configs..." ${Color_Off}
+	echo -e ${BBlue}"[*] Installing rofi configs in $ROFI_DIR" ${Color_Off}
 	{ mkdir -p "$ROFI_DIR"; cp -rf $DIR/files/* "$ROFI_DIR"; }
 
 	if [[ -f "$ROFI_DIR/config.rasi" ]]; then
-		echo -e ${BGreen}"[*] Successfully Installed.\n" ${Color_Off}
+		echo -e ${BGreen}"[*] Successfully Installed." ${Color_Off}
 		exit 0
 	else
-		echo -e ${BRed}"[!] Failed to install.\n" ${Color_Off}
+		echo -e ${BRed}"[!] Failed to install." ${Color_Off}
 		exit 1
 	fi
 }
@@ -49,7 +64,9 @@ install_themes() {
 # Main
 main() {
 	install_fonts
+    echo ""
 	install_themes
+    echo ""
 }
 
 main


### PR DESCRIPTION
This is some prep-work that allows for more portable installations.  This enables NixOS compatibility and a way for users to test things without messing with their existing rofi configurations.

* The `setup.sh` script is updated to support custom directories for installation location.  The script will still default to the old behavior, but users can have more control over where things are installed if they'd like.
* To support custom install locations, scripts have stopped using absolute paths, instead resolving their own file path and then using relative paths from there.  This should work on any system that has `readlink -f` support.
* Themes have also been updated to use relative paths for imports rather than absolute paths.
* To support read-only file-systems, users can now specify themes via the CLI. Examples below
  * `applets/bin/appasroot.sh type-1/style-2.rasi`
  * `launchers/type-1/launcher.sh 4`
  * `powermenu/type-1/launcher.sh 3`
* Env vars can be used to set certain commands in the apps applet
* `uptime` has multiple variations, some of which do not have a `-p` option. This implements a portable uptime in bash
* Still some more work to be done wrt portability for the audio commands and music player stuff.