### PR TITLE
added full support to use pywall theme to rofi

### DIFF
--- a/files/colors/pywal.rasi
+++ b/files/colors/pywal.rasi
@@ -1,0 +1,16 @@
+/**
+ *
+ * Author : Mallar Bhattacharya
+ * Github : @mallar-B
+ * 
+ * Colors
+ **/
+
+* {
+    background: #111213;
+    background-alt: #111213;
+    foreground: #ccc4ba;
+    selected: #6C6658;
+    active: #4E4F47;
+    urgent: #897559;
+}

--- a/files/scripts/pywal.sh
+++ b/files/scripts/pywal.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+background=$(sed -n 's/^ *background: *\(#\([0-9a-fA-F]\{6\}\)\);.*$/\1/p' ~/.cache/wal/colors-rofi-dark.rasi)
+foreground=$(sed -n 's/^ *foreground: *\(#\([0-9a-fA-F]\{6\}\)\);.*$/\1/p' ~/.cache/wal/colors-rofi-dark.rasi)
+selected_normal_background=$(sed -n 's/^ *selected-normal-background: *\(#\([0-9a-fA-F]\{6\}\)\);.*$/\1/p' ~/.cache/wal/colors-rofi-dark.rasi)
+selected_active_background=$(sed -n 's/^ *selected-active-background: *\(#\([0-9a-fA-F]\{6\}\)\);.*$/\1/p' ~/.cache/wal/colors-rofi-dark.rasi)
+selected_urgent_background=$(sed -n 's/^ *selected-urgent-background: *\(#\([0-9a-fA-F]\{6\}\)\);.*$/\1/p' ~/.cache/wal/colors-rofi-dark.rasi)
+
+sed -i "s/background: .*/background: $background;/" ~/.config/rofi/colors/pywal.rasi
+sed -i "s/background-alt: .*/background-alt: $background;/" ~/.config/rofi/colors/pywal.rasi
+sed -i "s/foreground: .*/foreground: $foreground;/" ~/.config/rofi/colors/pywal.rasi
+sed -i "s/selected: .*/selected: $selected_normal_background;/" ~/.config/rofi/colors/pywal.rasi
+sed -i "s/active: .*/active: $selected_active_background;/" ~/.config/rofi/colors/pywal.rasi
+sed -i "s/urgent: .*/urgent: $selected_urgent_background;/" ~/.config/rofi/colors/pywal.rasi


### PR DESCRIPTION
this will add `pywal.rasi` in `~/.config/rofi/colors/` and `pywal.sh` to `~/.config/rofi/scripts/`, After changing theme using `wal` command, running the script will result in adding the current pywal theme to pywal.rasi 