### PR TITLE
make tests for i3lock and betterlockscreen POSIX compliant

### DIFF
--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -74,7 +74,7 @@ run_cmd() {
 				openbox --exit
 			elif [[ "$DESKTOP_SESSION" == 'bspwm' ]]; then
 				bspc quit
-			elif [[ "$DESKTOP_SESSION" == 'i3' ]]; then
+			elif [[ "$DESKTOP_SESSION" =~ 'i3' ]]; then
 				i3-msg exit
 			elif [[ "$DESKTOP_SESSION" == 'plasma' ]]; then
 				qdbus org.kde.ksmserver /KSMServer logout 0 0 0

--- a/files/powermenu/type-1/powermenu.sh
+++ b/files/powermenu/type-1/powermenu.sh
@@ -95,9 +95,9 @@ case ${chosen} in
 		run_cmd --reboot
         ;;
     $lock)
-		if [[ -x '/usr/bin/betterlockscreen' ]]; then
+		if command -v betterlockscreen >/dev/null 2>&1; then
 			betterlockscreen -l
-		elif [[ -x '/usr/bin/i3lock' ]]; then
+		elif command -v i3lock >/dev/null 2>&1; then
 			i3lock
 		fi
         ;;

--- a/files/powermenu/type-2/powermenu.sh
+++ b/files/powermenu/type-2/powermenu.sh
@@ -96,9 +96,9 @@ case ${chosen} in
 		run_cmd --reboot
         ;;
     $lock)
-		if [[ -x '/usr/bin/betterlockscreen' ]]; then
+		if command -v betterlockscreen >/dev/null 2>&1; then
 			betterlockscreen -l
-		elif [[ -x '/usr/bin/i3lock' ]]; then
+		elif command -v i3lock >/dev/null 2>&1; then
 			i3lock
 		fi
         ;;

--- a/files/powermenu/type-3/powermenu.sh
+++ b/files/powermenu/type-3/powermenu.sh
@@ -90,9 +90,9 @@ case ${chosen} in
 		run_cmd --reboot
         ;;
     $lock)
-		if [[ -x '/usr/bin/betterlockscreen' ]]; then
+		if command -v betterlockscreen >/dev/null 2>&1; then
 			betterlockscreen -l
-		elif [[ -x '/usr/bin/i3lock' ]]; then
+		elif command -v i3lock >/dev/null 2>&1; then
 			i3lock
 		fi
         ;;

--- a/files/powermenu/type-4/powermenu.sh
+++ b/files/powermenu/type-4/powermenu.sh
@@ -90,9 +90,9 @@ case ${chosen} in
 		run_cmd --reboot
         ;;
     $lock)
-		if [[ -x '/usr/bin/betterlockscreen' ]]; then
+		if command -v betterlockscreen >/dev/null 2>&1; then
 			betterlockscreen -l
-		elif [[ -x '/usr/bin/i3lock' ]]; then
+		elif command -v i3lock >/dev/null 2>&1; then
 			i3lock
 		fi
         ;;

--- a/files/powermenu/type-5/powermenu.sh
+++ b/files/powermenu/type-5/powermenu.sh
@@ -102,9 +102,9 @@ case ${chosen} in
 		run_cmd --hibernate
         ;;
     $lock)
-		if [[ -x '/usr/bin/betterlockscreen' ]]; then
+		if command -v betterlockscreen >/dev/null 2>&1; then
 			betterlockscreen -l
-		elif [[ -x '/usr/bin/i3lock' ]]; then
+		elif command -v i3lock >/dev/null 2>&1; then
 			i3lock
 		fi
         ;;

--- a/files/powermenu/type-6/powermenu.sh
+++ b/files/powermenu/type-6/powermenu.sh
@@ -102,9 +102,9 @@ case ${chosen} in
 		run_cmd --hibernate
         ;;
     $lock)
-		if [[ -x '/usr/bin/betterlockscreen' ]]; then
+		if command -v betterlockscreen >/dev/null 2>&1; then
 			betterlockscreen -l
-		elif [[ -x '/usr/bin/i3lock' ]]; then
+		elif command -v i3lock >/dev/null 2>&1; then
 			i3lock
 		fi
         ;;

--- a/files/scripts/powermenu.sh
+++ b/files/scripts/powermenu.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+## Author : Aditya Shakya (adi1090x)
+## Github : @adi1090x
+#
+## Rofi   : Power Menu
+#
+## Available Styles
+#
+## style-1   style-2   style-3   style-4   style-5
+
+# Current Theme
+type="type-1"
+theme="style-1"
+
+# Parse flags
+while getopts "t:T:" opt; do
+  case $opt in
+    t) type="$OPTARG" ;;
+    T) theme="$OPTARG" ;;
+    \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+dir="$HOME/.config/rofi/powermenu/$type"
+
+# CMDs
+uptime="`uptime -p | sed -e 's/up //g'`"
+host=`hostname`
+
+# Options
+shutdown=' Shutdown'
+reboot=' Reboot'
+lock=' Lock'
+suspend=' Suspend'
+logout=' Logout'
+yes=' Yes'
+no=' No'
+
+# Rofi CMD
+rofi_cmd() {
+	rofi -dmenu \
+		-p "$host" \
+		-mesg "Uptime: $uptime" \
+		-theme ${dir}/${theme}.rasi
+}
+
+# Confirmation CMD
+confirm_cmd() {
+	rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 250px;}' \
+		-theme-str 'mainbox {children: [ "message", "listview" ];}' \
+		-theme-str 'listview {columns: 2; lines: 1;}' \
+		-theme-str 'element-text {horizontal-align: 0.5;}' \
+		-theme-str 'textbox {horizontal-align: 0.5;}' \
+		-dmenu \
+		-p 'Confirmation' \
+		-mesg 'Are you Sure?' \
+		-theme ${dir}/${theme}.rasi
+}
+
+# Ask for confirmation
+confirm_exit() {
+	echo -e "$yes\n$no" | confirm_cmd
+}
+
+# Pass variables to rofi dmenu
+run_rofi() {
+	echo -e "$lock\n$suspend\n$logout\n$reboot\n$shutdown" | rofi_cmd
+}
+
+# Execute Command
+run_cmd() {
+	selected="$(confirm_exit)"
+	if [[ "$selected" == "$yes" ]]; then
+		if [[ $1 == '--shutdown' ]]; then
+			systemctl poweroff
+		elif [[ $1 == '--reboot' ]]; then
+			systemctl reboot
+		elif [[ $1 == '--suspend' ]]; then
+			mpc -q pause
+			amixer set Master mute
+			systemctl suspend
+		elif [[ $1 == '--logout' ]]; then
+			if [[ "$DESKTOP_SESSION" == 'openbox' ]]; then
+				openbox --exit
+			elif [[ "$DESKTOP_SESSION" == 'bspwm' ]]; then
+				bspc quit
+			elif [[ "$DESKTOP_SESSION" =~ 'i3' ]]; then
+				i3-msg exit
+			elif [[ "$DESKTOP_SESSION" == 'plasma' ]]; then
+				qdbus org.kde.ksmserver /KSMServer logout 0 0 0
+			fi
+		fi
+	else
+		exit 0
+	fi
+}
+
+# Actions
+chosen="$(run_rofi)"
+case ${chosen} in
+    $shutdown)
+		run_cmd --shutdown
+        ;;
+    $reboot)
+		run_cmd --reboot
+        ;;
+    $lock)
+		if command -v betterlockscreen >/dev/null 2>&1; then
+			betterlockscreen -l
+		elif command -v i3lock >/dev/null 2>&1; then
+			i3lock
+		fi
+        ;;
+    $suspend)
+		run_cmd --suspend
+        ;;
+    $logout)
+		run_cmd --logout
+        ;;
+esac

--- a/files/scripts/powermenu.sh
+++ b/files/scripts/powermenu.sh
@@ -14,10 +14,10 @@ type="type-1"
 theme="style-1"
 
 # Parse flags
-while getopts "t:T:" opt; do
+while getopts "t:s:" opt; do
   case $opt in
     t) type="$OPTARG" ;;
-    T) theme="$OPTARG" ;;
+    s) theme="$OPTARG" ;;
     \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
   esac
 done

--- a/files/scripts/powermenu.sh
+++ b/files/scripts/powermenu.sh
@@ -16,8 +16,8 @@ theme="style-1"
 # Parse flags
 while getopts "t:s:" opt; do
   case $opt in
-    t) type="$OPTARG" ;;
-    s) theme="$OPTARG" ;;
+    t) type="type-$OPTARG" ;;
+    s) theme="style-$OPTARG" ;;
     \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
   esac
 done


### PR DESCRIPTION
The following check 

```bash
if [[ -x '/usr/bin/betterlockscreen' ]]; then
  betterlockscreen -l
elif [[ -x '/usr/bin/i3lock' ]]; then
  i3lock
fi
```

is not portable. For example, this check fails on nixos due to the way nix symlinks binaries.

`command` is the POSIX compliant manner to test for binaries. This fixes the issue I have with my nixos build, and should make it easier for newcomers to work with.